### PR TITLE
Add design for history page

### DIFF
--- a/src/app/pages/history/history.page.html
+++ b/src/app/pages/history/history.page.html
@@ -1,9 +1,117 @@
 <ion-header>
-  <ion-toolbar>
-    <ion-title>history</ion-title>
+  <ion-toolbar color=success>
+    <ion-title>Historial</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
+
+  <div *ngIf="myReports.length > 0">
+    <ion-card>
+      <ion-card-header>
+        <ion-grid>
+          <ion-row>
+            <ion-col size="9">
+              <ion-card-title>Aula 1</ion-card-title>
+            </ion-col>
+            <ion-col size="3" class="ion-align-self-center ion-text-right">
+              <span class="date-text">17/Oct/2020</span>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-card-header>
+    
+      <ion-card-content>
+        <span>Keep close to Nature's heart... and break clear away, once in awhile,
+          and climb a mountain or spend a week in the woods...
+        </span>
+      </ion-card-content>
+
+      <div class="ion-text-center">
+        <span><ion-text color="medium">Enviado</ion-text></span>
+      </div>
+      <ion-progress-bar value="0.33" buffer="0.66" color="medium"></ion-progress-bar>
+    </ion-card>
+
+    <ion-card>
+      <ion-card-header>
+        <ion-grid>
+          <ion-row>
+            <ion-col size="9">
+              <ion-card-title>Laboratorio 1</ion-card-title>
+            </ion-col>
+            <ion-col size="3" class="ion-align-self-center ion-text-right">
+              <span class="date-text">15/Oct/2020</span>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-card-header>
+    
+      <ion-card-content>
+        <span>Keep close to Nature's heart... and break clear away, once in awhile...
+        </span>
+      </ion-card-content>
+
+      <div class="ion-text-center">
+        <span><ion-text color="warning">En revisión</ion-text></span>
+      </div>
+      <ion-progress-bar value="0.66" buffer="0.90" color="warning"></ion-progress-bar>
+    </ion-card>
+
+    <ion-card>
+      <ion-card-header>
+        <ion-grid>
+          <ion-row>
+            <ion-col size="9">
+              <ion-card-title>Aula 4</ion-card-title>
+            </ion-col>
+            <ion-col size="3" class="ion-align-self-center ion-text-right">
+              <span class="date-text">01/Ago/2020</span>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-card-header>
+    
+      <ion-card-content>
+        <span>Keep close to Nature's heart... and break clear away, once in awhile,
+          and climb a mountain...
+        </span>
+      </ion-card-content>
+
+      <div class="ion-text-center">
+        <span><ion-text color="success">Aceptado</ion-text></span>
+      </div>
+      <ion-progress-bar value="1" buffer="0" color="success"></ion-progress-bar>
+    </ion-card>
+  </div>
+
+
+  <div *ngIf="myReports.length === 0">
+    <ion-card>
+      <ion-card-header>
+        <ion-grid>
+          <ion-row>
+            <ion-col size="9">
+              <ion-card-title>
+                <ion-skeleton-text animated style="width: 65%; height: 15px;"></ion-skeleton-text>
+              </ion-card-title>
+            </ion-col>
+            <ion-col size="3" class="ion-align-self-center ion-text-right">
+              <span class="date-text">
+                <ion-skeleton-text animated style="width: 100%; height: 15px;"></ion-skeleton-text>
+              </span>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-card-header>
+    
+      <ion-card-content>
+        <ion-skeleton-text animated></ion-skeleton-text>
+        <ion-skeleton-text animated style="width: 85%;"></ion-skeleton-text>
+        <ion-skeleton-text animated style="width: 65%;"></ion-skeleton-text>
+      </ion-card-content>
+      <ion-skeleton-text animated></ion-skeleton-text>
+    </ion-card>
+  </div>
 
 </ion-content>

--- a/src/app/pages/history/history.page.scss
+++ b/src/app/pages/history/history.page.scss
@@ -1,0 +1,20 @@
+ion-card {
+  border-radius: 12px;
+}
+
+ion-card-header {
+  padding-top: 10px;
+  padding-bottom: 5px;
+}
+
+ion-grid {
+  padding: 0px;
+}
+
+ion-col {
+  padding: 0px;
+}
+
+.date-text {
+  font-size: 12px;
+}

--- a/src/app/pages/history/history.page.ts
+++ b/src/app/pages/history/history.page.ts
@@ -7,9 +7,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HistoryPage implements OnInit {
 
+  myReports:any[] = [];
+
   constructor() { }
 
   ngOnInit() {
+    setTimeout(() => {
+      this.myReports.push(1,2,3);
+    }, 2500);
   }
 
 }


### PR DESCRIPTION
This adds first design for history page.

### Example interface for Android phone
<img width="417" alt="Screen Shot 2020-10-17 at 17 40 20" src="https://user-images.githubusercontent.com/32939860/96354948-f6b88900-10a1-11eb-979c-d22c797ab305.png">
